### PR TITLE
:bug: Support chunked responses in atomic relay

### DIFF
--- a/bus-vortex/src/main/java/org/miaixz/bus/vortex/Octets.java
+++ b/bus-vortex/src/main/java/org/miaixz/bus/vortex/Octets.java
@@ -71,13 +71,14 @@ public final class Octets {
     /**
      * Reads a bounded response into exact-sized heap segments for later atomic relay.
      * <p>
-     * A non-negative Content-Length is mandatory. Its exact logical size is acquired before source subscription and
-     * remains owned by the returned body until that body is closed.
+     * A known Content-Length reserves its exact logical size. When the length is unknown, the configured per-body
+     * limit is reserved before source subscription and reduced to the materialized size after completion. The retained
+     * logical size remains owned by the returned body until that body is closed.
      *
      * @param body           source response buffers
      * @param maxBytes       per-body materialization limit
      * @param budget         process-wide response-byte budget
-     * @param expectedLength declared Content-Length
+     * @param expectedLength declared Content-Length, or {@code -1} when the transfer length is unknown
      * @return buffered response with an attached logical-byte lease
      */
     public static Mono<BufferedBody> readForRelay(
@@ -85,17 +86,44 @@ public final class Octets {
             int maxBytes,
             AsyncByteBudget budget,
             long expectedLength) {
-        Mono<Void> validation = validateKnownLength(body, maxBytes, budget, expectedLength);
+        Mono<Void> validation = validateRelayLength(body, maxBytes, budget, expectedLength);
         if (validation != null) {
             return validation.then(Mono.empty());
         }
-        return awaitBufferingCapacity().then(budget.acquire(expectedLength))
+        long reservedLength = expectedLength >= 0 ? expectedLength : maxBytes;
+        return awaitBufferingCapacity().then(budget.acquire(reservedLength))
                 .timeout(Duration.ofSeconds(Holder.get().getBufferAcquireTimeoutSeconds()))
                 .onErrorMap(
                         java.util.concurrent.TimeoutException.class,
                         error -> new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
                                 "Buffered-byte capacity wait timed out", error))
                 .flatMap(lease -> readReservedSegmented(body, maxBytes, expectedLength, lease));
+    }
+
+    /**
+     * Validates relay prerequisites before a budget is acquired or the source is subscribed.
+     *
+     * @param body           source body
+     * @param maxBytes       positive per-body limit
+     * @param budget         process-wide response-byte budget
+     * @param expectedLength declared Content-Length, or {@code -1} when unknown
+     * @return an error publisher when validation fails, or {@code null} when validation succeeds
+     */
+    private static Mono<Void> validateRelayLength(
+            Flux<? extends DataBuffer> body,
+            int maxBytes,
+            AsyncByteBudget budget,
+            long expectedLength) {
+        if (body == null || budget == null || maxBytes <= 0) {
+            return Mono.error(new IllegalArgumentException("body, positive maxBytes and budget are required"));
+        }
+        if (expectedLength < -1) {
+            return Mono.error(new IllegalArgumentException("expectedLength must be -1 or greater"));
+        }
+        if (expectedLength > maxBytes) {
+            return Mono.error(new DataBufferLimitException("Exceeded buffered body limit of " + maxBytes + " bytes"));
+        }
+        return null;
     }
 
     /**
@@ -195,12 +223,12 @@ public final class Octets {
     }
 
     /**
-     * Consumes a response into segments after its exact capacity has already been acquired.
+     * Consumes a response into segments after bounded capacity has already been acquired.
      *
      * @param body           source response buffers
      * @param maxBytes       per-body materialization limit
-     * @param expectedLength declared and reserved Content-Length
-     * @param lease          exact response-byte lease
+     * @param expectedLength declared Content-Length, or {@code -1} when unknown
+     * @param lease          bounded response-byte lease
      * @return segmented buffered body that assumes ownership of the lease
      */
     private static Mono<BufferedBody> readReservedSegmented(
@@ -208,13 +236,15 @@ public final class Octets {
             int maxBytes,
             long expectedLength,
             AsyncByteBudget.Lease lease) {
-        SegmentAccumulator accumulator = new SegmentAccumulator(expectedLength);
+        long bodyLimit = expectedLength >= 0 ? expectedLength : maxBytes;
+        SegmentAccumulator accumulator = new SegmentAccumulator(bodyLimit);
         return body.<Integer>handle((buffer, sink) -> {
             try {
                 int bytes = buffer.readableByteCount();
-                if ((long) accumulator.length() + bytes > expectedLength
-                        || (long) accumulator.length() + bytes > maxBytes) {
-                    sink.error(new DataBufferLimitException("Body exceeds declared Content-Length"));
+                if ((long) accumulator.length() + bytes > bodyLimit) {
+                    String message = expectedLength >= 0 ? "Body exceeds declared Content-Length"
+                            : "Exceeded buffered body limit of " + maxBytes + " bytes";
+                    sink.error(new DataBufferLimitException(message));
                     return;
                 }
                 accumulator.append(buffer);
@@ -223,8 +253,11 @@ public final class Octets {
                 release(buffer);
             }
         }).then(Mono.defer(() -> {
-            if (accumulator.length() != expectedLength) {
+            if (expectedLength >= 0 && accumulator.length() != expectedLength) {
                 return Mono.error(new DataBufferLimitException("Body length does not match Content-Length"));
+            }
+            if (expectedLength < 0) {
+                lease.shrinkTo(accumulator.length());
             }
             return Mono.just(accumulator.body(lease));
         })).doOnError(error -> lease.close()).doOnCancel(lease::close)
@@ -243,7 +276,7 @@ public final class Octets {
         private final List<byte[]> segments;
 
         /**
-         * Declared body length used to size the final segment without over-allocation.
+         * Maximum body length used to size the final segment without over-allocation.
          */
         private final int expectedLength;
 
@@ -253,9 +286,9 @@ public final class Octets {
         private int length;
 
         /**
-         * Creates an empty accumulator sized from a previously validated Content-Length.
+         * Creates an empty accumulator sized from a previously validated body limit.
          *
-         * @param expectedLength exact number of bytes expected from the source
+         * @param expectedLength maximum number of bytes accepted from the source
          */
         private SegmentAccumulator(long expectedLength) {
             this.expectedLength = Math.toIntExact(expectedLength);

--- a/bus-vortex/src/main/java/org/miaixz/bus/vortex/guard/AsyncByteBudget.java
+++ b/bus-vortex/src/main/java/org/miaixz/bus/vortex/guard/AsyncByteBudget.java
@@ -23,6 +23,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
 import reactor.core.publisher.Mono;
@@ -281,7 +282,7 @@ public final class AsyncByteBudget implements AutoCloseable {
     }
 
     /**
-     * Idempotent ownership token for an exact number of logical bytes.
+     * Idempotent ownership token for a bounded number of logical bytes.
      */
     public static final class Lease implements AutoCloseable {
 
@@ -291,14 +292,9 @@ public final class AsyncByteBudget implements AutoCloseable {
         private final AsyncByteBudget budget;
 
         /**
-         * Exact logical bytes charged to the budget.
+         * Logical bytes currently charged to the budget.
          */
-        private final long bytes;
-
-        /**
-         * Ensures capacity is returned only once.
-         */
-        private final AtomicBoolean closed = new AtomicBoolean();
+        private final AtomicLong bytes;
 
         /**
          * Creates an ownership token for capacity already charged to the budget.
@@ -308,16 +304,38 @@ public final class AsyncByteBudget implements AutoCloseable {
          */
         private Lease(AsyncByteBudget budget, long bytes) {
             this.budget = budget;
-            this.bytes = bytes;
+            this.bytes = new AtomicLong(bytes);
         }
 
         /**
-         * Returns the capacity owned by this lease.
+         * Returns the capacity currently owned by this lease.
          *
-         * @return exact logical bytes owned by this lease
+         * @return logical bytes currently owned by this lease
          */
         public long bytes() {
-            return this.bytes;
+            return this.bytes.get();
+        }
+
+        /**
+         * Reduces this lease to the supplied number of logical bytes and immediately returns the unused capacity.
+         * <p>
+         * This operation is intended for bounded bodies whose exact size becomes known only after materialization.
+         * It is safe to race with {@link #close()}; capacity is returned exactly once.
+         *
+         * @param retainedBytes logical bytes that must remain owned by this lease
+         */
+        public void shrinkTo(long retainedBytes) {
+            long current;
+            do {
+                current = this.bytes.get();
+                if (retainedBytes < 0 || retainedBytes > current) {
+                    throw new IllegalArgumentException("retainedBytes must be in range 0.." + current);
+                }
+                if (retainedBytes == current) {
+                    return;
+                }
+            } while (!this.bytes.compareAndSet(current, retainedBytes));
+            this.budget.release(current - retainedBytes);
         }
 
         /**
@@ -325,8 +343,9 @@ public final class AsyncByteBudget implements AutoCloseable {
          */
         @Override
         public void close() {
-            if (this.closed.compareAndSet(false, true) && this.bytes > 0) {
-                this.budget.release(this.bytes);
+            long ownedBytes = this.bytes.getAndSet(0);
+            if (ownedBytes > 0) {
+                this.budget.release(ownedBytes);
             }
         }
     }

--- a/bus-vortex/src/main/java/org/miaixz/bus/vortex/routing/rest/RestExecutor.java
+++ b/bus-vortex/src/main/java/org/miaixz/bus/vortex/routing/rest/RestExecutor.java
@@ -69,8 +69,9 @@ import reactor.core.publisher.Mono;
  * downstream response back into a {@link ServerResponse} for the original client.
  * <p>
  * The route asset explicitly selects bounded atomic relay, realtime streaming or protected file download. Atomic
- * responses require Content-Length and retain an exact logical-byte lease through the network write; streaming modes
- * preserve downstream backpressure and never aggregate the body.
+ * responses enforce a bounded materialization limit and retain an exact logical-byte lease through the network write;
+ * both fixed-length and chunked downstream responses are supported. Streaming modes preserve downstream backpressure
+ * and never aggregate the body.
  * <p>
  * Generic type parameters: {@code Executor<ServerRequest, ServerResponse>}
  *
@@ -578,9 +579,10 @@ public class RestExecutor extends Coordinator<ServerRequest, ServerResponse> {
     /**
      * Handles the execution for an ATOMIC request using buffered downstream response passthrough.
      * <p>
-     * The downstream response requires Content-Length, acquires that exact logical capacity, and is materialized into
-     * bounded segments before the {@link ServerResponse} is returned. Ownership remains active through the gateway
-     * network write, including cancellation.
+     * The downstream response is materialized into bounded segments before the {@link ServerResponse} is returned.
+     * Fixed-length responses acquire their declared capacity; chunked responses acquire the configured upper bound and
+     * reduce it to the actual size after completion. Ownership remains active through the gateway network write,
+     * including cancellation.
      * </p>
      *
      * @param bodySpec  the downstream request specification
@@ -691,10 +693,10 @@ public class RestExecutor extends Coordinator<ServerRequest, ServerResponse> {
         }
 
         long declaredLength = responseEntity.getHeaders().getContentLength();
-        if (declaredLength < 0 || declaredLength > Math.toIntExact(Holder.get().getMaxBufferedResponseSize())) {
+        if (declaredLength > Math.toIntExact(Holder.get().getMaxBufferedResponseSize())) {
             return discardResponseBody(bodyFlux).then(
                     Mono.error(
-                            new DataBufferLimitException("Atomic response requires Content-Length in range 0.."
+                            new DataBufferLimitException("Atomic response exceeds the buffered body limit of "
                                     + Math.toIntExact(Holder.get().getMaxBufferedResponseSize()))));
         }
 
@@ -705,7 +707,7 @@ public class RestExecutor extends Coordinator<ServerRequest, ServerResponse> {
                 return Mono.error(new IllegalStateException("Vortex request context is missing"));
             }
             int bodyLength = body.length();
-            if (bodyLength != declaredLength) {
+            if (declaredLength >= 0 && bodyLength != declaredLength) {
                 return Mono.error(
                         new DataBufferLimitException("Atomic response length mismatch: declared=" + declaredLength
                                 + ", actual=" + bodyLength));
@@ -731,7 +733,7 @@ public class RestExecutor extends Coordinator<ServerRequest, ServerResponse> {
      * Collects a downstream response body while enforcing the buffered-response size limit.
      *
      * @param bodyFlux       downstream response buffers
-     * @param declaredLength validated downstream Content-Length
+     * @param declaredLength validated downstream Content-Length, or {@code -1} when unknown
      * @return buffered body with an attached response-byte lease
      */
     private Mono<Octets.BufferedBody> collectBufferedBody(Flux<DataBuffer> bodyFlux, long declaredLength) {


### PR DESCRIPTION
## Summary

- accept downstream REST responses without `Content-Length` in atomic relay mode
- enforce the configured buffered-response limit while collecting chunked bodies
- shrink the reserved response-byte budget to the actual materialized length after completion
- preserve existing validation for declared lengths and length mismatches

## Verification

- `mvn -f bus-vortex/pom.xml -Dmaven.compiler.release=21 -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 -DskipTests clean compile`

## Context

Downstream services may return successful JSON responses with `Transfer-Encoding: chunked`. Previously, atomic relay rejected them before reading the body because `Content-Length` was unavailable.